### PR TITLE
Added timeout on request to work-around SSE disconnected

### DIFF
--- a/huemagic/utils/api.js
+++ b/huemagic/utils/api.js
@@ -62,6 +62,7 @@ function API()
 					"Content-Type": "application/json; charset=utf-8",
 					"hue-application-key": config.key
 				},
+				"timeout": 3000,
 				"httpsAgent": new https.Agent({ rejectUnauthorized: false }), // Node is somehow not able to parse the official Philips Hue PEM
 			};
 


### PR DESCRIPTION
As described in some submitted bugs the bridge connection sometimes gets lost.
I personally have this issue 'sometimes', but certainly every time my router auto-restarts (1x a week).
Bugs references I found :
- https://github.com/mauricedominic/node-red-contrib-huemagic/issues/4#issue-1584999867
- https://github.com/mauricedominic/node-red-contrib-huemagic/issues/21#issue-2073728230
- https://github.com/mauricedominic/node-red-contrib-huemagic/issues/19#issue-2060699200

I found out that the HueMagic engine has its own watchdog to check whether connection is up or not and re-connect if necessary.
However, it is not 100% reliable, and this is caused by the way the Hue bridge works with SSE (Server Side Events).
1. HueMagic subscribe to the bridge SSE.
2. Every time something occurs (button press, light change,...) , it sends an event to the subscriber (HueMagic)
3. If bridge loses connection to subscriber, it stops trying to send updates. The subscriber should re-subscribe.

But the watchdog does 'only' check whether the Hue bridge is up, not if it is still registered as a subscriber...
There are 2 limitations to this way of working :
- if the bridge can be connected (=network-wise), it does not mean HueMagic is still being an active subscriber receiving SSE updates
- when host is unreachable (network down), HueMagic waits for the answer... and will only react on error. But if the bridge is up again after some seconds/minutes, a return message is received... while SSE was never re-subscribed

I was able to work-around the second issue : there was no time-out on calls made, which means even if the bridge was unreachable for a few minutes, it did not trigger a re-connection.
by adding a time-out of 3s to requests send, it solved the issue. The time-out could be set as a param in config but since I never have any request with a >1s delay, it should be OK for all.
I also -personally- did not encounter any disconnection at all... but it remains not 100% SSE-disconnection-proof ...


Note: Normally, most SSE providers have a 'keep-alive' concept which sends regularly an event to subscriber so that it is able to know it is still up...
... an act accordingly by trying to re-subscribe when the 'keep alive' message stops coming in.

The Hue Bridge does not offer any 'keep alive' mechanism :-(
It seems other tools would also like it... I even found this work-around which uses geofence to ensure responses should always be regularly sent as a keep-alive:
https://github.com/home-assistant-libs/aiohue/blob/58b24e2ad0dd212f34a780689d0d90aa050a80dd/aiohue/v2/controllers/events.py#L284
(which is quite complex and which I -personally- would not be able to integrate into current HueMagic engine)

@mauricedominic : could be interesting to merge the the main active fork too I guess
